### PR TITLE
ci: skip review for fork PRs to protect secrets

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   opencode-review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Adds `if: github.event.pull_request.head.repo.full_name == github.repository` so the review workflow only runs on PRs from the same repo. Fork PRs are skipped silently, preventing secrets from being exposed.